### PR TITLE
Youtube playlist

### DIFF
--- a/app/controllers/admin/tutorials_controller.rb
+++ b/app/controllers/admin/tutorials_controller.rb
@@ -6,6 +6,7 @@ class Admin::TutorialsController < Admin::BaseController
   def create
     tutorial = Tutorial.create(create_tutorial_params)
     if tutorial.save
+      vids= YoutubeResults.new.create_videos(tutorial)
       flash[:notice] = "Successfully created tutorial. #{view_context.link_to("View it here.", tutorial_path(tutorial.id))}"
       redirect_to admin_dashboard_path
     end

--- a/app/controllers/admin/tutorials_controller.rb
+++ b/app/controllers/admin/tutorials_controller.rb
@@ -6,7 +6,7 @@ class Admin::TutorialsController < Admin::BaseController
   def create
     tutorial = Tutorial.create(create_tutorial_params)
     if tutorial.save
-      vids= YoutubeResults.new.create_videos(tutorial)
+      YoutubeResults.new.create_videos(tutorial)
       flash[:notice] = "Successfully created tutorial. #{view_context.link_to("View it here.", tutorial_path(tutorial.id))}"
       redirect_to admin_dashboard_path
     end

--- a/app/controllers/admin/tutorials_controller.rb
+++ b/app/controllers/admin/tutorials_controller.rb
@@ -3,7 +3,13 @@ class Admin::TutorialsController < Admin::BaseController
     @tutorial = Tutorial.find(params[:id])
   end
 
-  def create; end
+  def create
+    tutorial = Tutorial.create(create_tutorial_params)
+    if tutorial.save
+      flash[:notice] = "Successfully created tutorial. #{view_context.link_to("View it here.", tutorial_path(tutorial.id))}"
+      redirect_to admin_dashboard_path
+    end
+  end
 
   def new
     @tutorial = Tutorial.new
@@ -26,4 +32,9 @@ class Admin::TutorialsController < Admin::BaseController
   def tutorial_params
     params.require(:tutorial).permit(:tag_list)
   end
+
+  def create_tutorial_params
+    params.require(:tutorial).permit(:title, :description, :thumbnail, :playlist_id)
+  end
+
 end

--- a/app/models/tutorial.rb
+++ b/app/models/tutorial.rb
@@ -1,5 +1,6 @@
 class Tutorial < ApplicationRecord
-  has_many :videos, -> { order(position: :ASC) }, inverse_of: :tutorial
+  has_many :videos
+  # , -> { order(position: :ASC) }, inverse_of: :tutorial
   acts_as_taggable_on :tags, :tag_list
   accepts_nested_attributes_for :videos
 end

--- a/app/poros/youtube_results.rb
+++ b/app/poros/youtube_results.rb
@@ -1,0 +1,6 @@
+class YoutubeResults
+  def create_videos(tutorial)
+    json = YoutubeService.new.playlist_info(tutorial.playlist_id)
+    json[:items].map { |video_data| }
+  end
+end

--- a/app/poros/youtube_results.rb
+++ b/app/poros/youtube_results.rb
@@ -1,6 +1,6 @@
 class YoutubeResults
   def create_videos(tutorial)
-    json = YoutubeService.new.playlist_info(tutorial.playlist_id)
-    json[:items].map { |video_data| }
+    json = YoutubeService.new.playlist_video_data(tutorial.playlist_id)
+    json.each { |video_data| tutorial.videos.create(video_data) }
   end
 end

--- a/app/services/youtube_service.rb
+++ b/app/services/youtube_service.rb
@@ -7,7 +7,7 @@ class YoutubeService
 
   def playlist_video_data(id)
     data = playlist_info(id)
-    data[:items].map do |video|
+    video_data = data[:items].map do |video|
       {
         video_id: video[:id],
         title: video[:snippet][:title],
@@ -15,12 +15,24 @@ class YoutubeService
         description: video[:snippet][:description]
       }
     end
+    while data[:nextPageToken]
+      data = playlist_info(id, data[:nextPageToken])
+      video_data +=  data[:items].map do |video|
+        {
+          video_id: video[:id],
+          title: video[:snippet][:title],
+          thumbnail: video[:snippet][:thumbnails][:high][:url],
+          description: video[:snippet][:description]
+        }
+      end
+    end
+    video_data
   end
 
   private
 
-  def playlist_info(id)
-    params = { part: 'snippet,contentDetails', playlistId: id, maxResults: 100 }
+  def playlist_info(id, nextPageToken=nil)
+    params = { part: 'snippet,contentDetails', playlistId: id, maxResults: 100, pageToken: nextPageToken }
 
     get_json('youtube/v3/playlistItems', params)
   end

--- a/app/services/youtube_service.rb
+++ b/app/services/youtube_service.rb
@@ -5,6 +5,12 @@ class YoutubeService
     get_json('youtube/v3/videos', params)
   end
 
+  def playlist_info(id)
+    params = { part: 'snippet,contentDetails', playlistId: id, maxResults: 100 }
+
+    get_json('youtube/v3/playlistItems', params)
+  end
+
   private
 
   def get_json(url, params)

--- a/app/services/youtube_service.rb
+++ b/app/services/youtube_service.rb
@@ -5,13 +5,25 @@ class YoutubeService
     get_json('youtube/v3/videos', params)
   end
 
+  def playlist_video_data(id)
+    data = playlist_info(id)
+    data[:items].map do |video|
+      {
+        video_id: video[:id],
+        title: video[:snippet][:title],
+        thumbnail: video[:snippet][:thumbnails][:high][:url],
+        description: video[:snippet][:description]
+      }
+    end
+  end
+
+  private
+
   def playlist_info(id)
     params = { part: 'snippet,contentDetails', playlistId: id, maxResults: 100 }
 
     get_json('youtube/v3/playlistItems', params)
   end
-
-  private
 
   def get_json(url, params)
     response = conn.get(url, params)

--- a/app/views/admin/tutorials/new.html.erb
+++ b/app/views/admin/tutorials/new.html.erb
@@ -9,6 +9,16 @@
 
   <h3>Videos</h3>
 
+  <div data-controller="tutorials">
+    <%= link_to "Import Youtube Playlist", "#", "data-action" => "click->tutorials#showVideoForm", class: "video-position-submit btn btn-outline", id: @tutorial.id %>
+  </div>
+
+  <div class="mt1" id="new-video-form">
+    <h3>Import Playlist</h3>
+    <%= f.label 'Playlist Id', class: "block" %>
+    <%= f.text_field :playlist_id, class: "field block"%>
+  </div>
+
   <%= f.fields_for :videos do |builder| %>
     <%= f.label :youtube_url %>
     <%= f.text_field :video_id, class: "block col-4 field" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,7 +16,7 @@
     <main class="px4">
       <div class="flash-message">
         <% flash.each do |name, msg| %>
-          <%= content_tag :div, msg, class: name %>
+          <%= content_tag :div, msg.html_safe, class: name %>
         <% end %>
       </div>
 

--- a/spec/features/admin/admin_can_import_youtube_palylist_spec.rb
+++ b/spec/features/admin/admin_can_import_youtube_palylist_spec.rb
@@ -17,5 +17,8 @@ describe "An admin can import a youtube playlist" do
 
     expect(current_path).to eq(admin_dashboard_path)
     expect(page).to have_content('Successfully created tutorial. View it here.')
+
+    click_link "View it here."
+    expect(current_path).to eq(tutorial_path(Tutorial.last.id))
   end
 end

--- a/spec/features/admin/admin_can_import_youtube_palylist_spec.rb
+++ b/spec/features/admin/admin_can_import_youtube_palylist_spec.rb
@@ -1,9 +1,13 @@
 require 'rails_helper'
 
 describe "An admin can import a youtube playlist" do
+
+  before :each do
+    @admin = create(:admin)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@admin)
+
+  end
   it "from the new admin tutorial path" do
-    admin = create(:admin)
-    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
     visit new_admin_tutorial_path
 
     fill_in 'Title', with: "New Tutorial"
@@ -18,6 +22,27 @@ describe "An admin can import a youtube playlist" do
     expect(page).to have_content('Successfully created tutorial. View it here.')
 
     click_link "View it here."
-    expect(current_path).to eq(tutorial_path(Tutorial.last.id))
+    tutorial = Tutorial.last
+    expect(current_path).to eq(tutorial_path(tutorial.id))
+
+    video = Video.last
+    expect(video.tutorial_id).to eq(tutorial.id)
   end
+
+  it "retains original sequence and can be longer than 50 videos" do
+    visit new_admin_tutorial_path
+
+    fill_in 'Title', with: "New Tutorial"
+    fill_in 'Description', with: "New Tutorial Description"
+    fill_in 'Thumbnail', with: "https://i.ytimg.com/vi/qMkRHW9zE1c/hqdefault.jpg"
+
+    click_link "Import Youtube Playlist"
+    fill_in 'tutorial_playlist_id', with: 'PLDIoUOhQQPlXr63I_vwF9GD8sAKh77dWU'
+    click_on 'Save'
+    click_link "View it here."
+    tutorial = Tutorial.last
+    expect(tutorial.videos.count).to be > 50
+    expect(tutorial.videos.first.title).to eq('DaBaby – ROCKSTAR FT RODDY RICCH [Audio]')
+  end
+
 end

--- a/spec/features/admin/admin_can_import_youtube_palylist_spec.rb
+++ b/spec/features/admin/admin_can_import_youtube_palylist_spec.rb
@@ -5,8 +5,7 @@ describe "An admin can import a youtube playlist" do
     admin = create(:admin)
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
     visit new_admin_tutorial_path
-    # y = YoutubeService.new.playlist_info('RDQMVYZqmir5xl0')
-    # require "pry"; binding.pry
+
     fill_in 'Title', with: "New Tutorial"
     fill_in 'Description', with: "New Tutorial Description"
     fill_in 'Thumbnail', with: "https://i.ytimg.com/vi/qMkRHW9zE1c/hqdefault.jpg"

--- a/spec/features/admin/admin_can_import_youtube_palylist_spec.rb
+++ b/spec/features/admin/admin_can_import_youtube_palylist_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+describe "An admin can import a youtube playlist" do
+  it "from the new admin tutorial path" do
+    admin = create(:admin)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+    visit new_admin_tutorial_path
+    # y = YoutubeService.new.playlist_info('RDQMVYZqmir5xl0')
+    # require "pry"; binding.pry
+    fill_in 'Title', with: "New Tutorial"
+    fill_in 'Description', with: "New Tutorial Description"
+    fill_in 'Thumbnail', with: "https://i.ytimg.com/vi/qMkRHW9zE1c/hqdefault.jpg"
+
+    click_link "Import Youtube Playlist"
+    fill_in 'tutorial_playlist_id', with: 'RDQMVYZqmir5xl0'
+    click_on 'Save'
+
+    expect(current_path).to eq(admin_dashboard_path)
+    expect(page).to have_content('Successfully created tutorial. View it here.')
+  end
+end


### PR DESCRIPTION
Admin can now import a youtube playlist when creating a new tutorial.
The playlist field in the form opens when the user clicks a link.
All parts of the user story are covered, but we still need to add a sad path for creating a tutorial.